### PR TITLE
Do case-insensitive comparison of literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The options are:
 
 ## How it Works
 
-The parser uses [PEG.js](http://pegjs.majda.cz/) and is an extension of the example JSON parser included in that project.
+The parser uses [PEG.js](https://pegjs.org/) and is an extension of the example JSON parser included in that project.
 
 [npm-badge]: https://badge.fury.io/js/jsonic.svg
 [npm-url]: https://badge.fury.io/js/jsonic

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ JSONIC format is just standard JSON, with a few rule relaxations:
    * You _do_ need to quote strings if they contain a comma or closing brace or square bracket: <code>icky:"_,}]_"</code>
    * You can use single quotes for strings: <code>Jules:'Cry "Havoc," and let slip the dogs of war!'</code>
    * You can have trailing commas: <code>foo:bar, red:255, </code>
+   * You can have true, false, and null be any case: <code>foo: True</code>
 
 
 # Stringify

--- a/jsonic-parser.pegjs
+++ b/jsonic-parser.pegjs
@@ -58,9 +58,9 @@ value
   / single
   / object
   / array
-  / "true" _  { return true;  }
-  / "false" _ { return false; }
-  / "null" _  { return null_; }
+  / "true"i _  { return true;  }
+  / "false"i _ { return false; }
+  / "null"i _  { return null_; }
   / number
   / lit:literal { return lit.join('').trim() }
 

--- a/jsonic.js
+++ b/jsonic.js
@@ -896,7 +896,7 @@ var jsonic_parser = (function() {
             s0 = peg$parsearray();
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 4) === peg$c24) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c24) {
                 s1 = peg$c24;
                 peg$currPos += 4;
               } else {
@@ -919,7 +919,7 @@ var jsonic_parser = (function() {
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 5) === peg$c27) {
+                if (input.substr(peg$currPos, 5).toLowerCase() === peg$c27) {
                   s1 = peg$c27;
                   peg$currPos += 5;
                 } else {
@@ -942,7 +942,7 @@ var jsonic_parser = (function() {
                 }
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 4) === peg$c30) {
+                  if (input.substr(peg$currPos, 4).toLowerCase() === peg$c30) {
                     s1 = peg$c30;
                     peg$currPos += 4;
                   } else {


### PR DESCRIPTION
[EDIT] I have come to the disappointing realization that modifying jsonic.js was the wrong way to go about this, but I'm having difficulty figuring out how to do it the right way because build.sh assumes there's a node_modules/.bin with things like pegjs in it, and I am not sure how to get that set up :-(

Allow `true`, `false`, and `null` no matter what case by forcing the input to lower case before comparing to the respective tokens.

The motivation for this PR is that I've found openapi spec files that use literals appearing as `True` and `False` at https://github.com/infobloxopen/infoblox-swagger-wapi/tree/master/infoblox-swagger-ui/dist/v2.11