### PR TITLE
Update README: replace docs link to avoid risk from expired domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Also, it's very __very__ extensible.*
 
 `a:1,foo:bar` &rarr; `{"a": 1, "foo": "bar"}`
 
-[Site](https://jsonic.com/) |
-[Docs](https://jsonic.com/docs) |
+[Site](https://jsonic.richardrodger.com/) |
+[Reference](https://jsonic.richardrodger.com/ref/) |
 [FP Guide](https://github.com/jsonic/jsonic/wiki/FP-Guide) |
 [Contributing](https://github.com/jsonic/jsonic/blob/master/.github/CONTRIBUTING.md) |
 [Wiki](https://github.com/jsonic/jsonic/wiki "Changelog, Roadmap, etc.") |


### PR DESCRIPTION
### Summary

The documentation URL in the README pointed to a domain that is currently listed for sale.  
The actual documentation appears to be hosted on GitHub Pages, and continuing to reference the expired domain may pose a security risk.

This PR updates the link to point directly to the correct GitHub Pages URL to avoid any potential confusion or misuse.

### Motivation

- The old domain is no longer controlled by the project and is currently for sale.
- There is a risk that the domain could be acquired by a third party and used maliciously (e.g., phishing).
- Updating the URL helps maintain trust and accuracy in the project documentation.

