### PR TITLE
Fix SetOptions to preserve rule modifications (clone/inherit parity)

### DIFF
--- a/go/grammar_decl_test.go
+++ b/go/grammar_decl_test.go
@@ -738,3 +738,123 @@ func TestGrammarOptionsMapAtEscape(t *testing.T) {
 		t.Errorf("expected @literal-at, got %v", j.Options().Tag)
 	}
 }
+
+// --- SetOptions preserves rule modifications (clone/inherit parity) ---
+
+func TestSetOptionsPreservesRuleModifications(t *testing.T) {
+	// In TS, j.rule() then j.options() preserves the rule modification.
+	// This test verifies Go matches that behavior.
+	j := Make()
+
+	// Add a custom close alt to val via Rule().
+	tagged := false
+	j.Rule("val", func(rs *RuleSpec) {
+		rs.Close = append([]*AltSpec{{
+			A: func(r *Rule, ctx *Context) { tagged = true },
+			G: "custom-tag",
+		}}, rs.Close...)
+	})
+
+	// Now call SetOptions — this must NOT destroy the rule modification.
+	yes := true
+	j.SetOptions(Options{
+		Number: &NumberOptions{Hex: &yes},
+	})
+
+	// The custom alt should still be in val.Close.
+	valClose := j.RSM()["val"].Close
+	found := false
+	for _, alt := range valClose {
+		if alt.G == "custom-tag" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("rule modification lost after SetOptions — val.Close missing custom-tag alt")
+	}
+
+	// Parse should work and trigger the custom action.
+	_, err := j.Parse("a:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tagged {
+		t.Error("custom action did not fire after SetOptions")
+	}
+}
+
+func TestSetOptionsPreservesGrammarModifications(t *testing.T) {
+	// Grammar() then SetOptions() should preserve the grammar modifications.
+	j := Make()
+
+	marked := false
+	mustGrammar(t, j, &GrammarSpec{
+		Ref: map[FuncRef]any{
+			"@mark": AltAction(func(r *Rule, ctx *Context) {
+				marked = true
+			}),
+		},
+		Rule: map[string]*GrammarRuleSpec{
+			"val": {
+				Close: []*GrammarAltSpec{
+					{A: "@mark", G: "grammar-mod"},
+				},
+			},
+		},
+	})
+
+	// SetOptions after Grammar should NOT destroy the grammar modification.
+	sep := "_"
+	j.SetOptions(Options{
+		Number: &NumberOptions{Sep: sep},
+	})
+
+	_, err := j.Parse("a:1_000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !marked {
+		t.Error("grammar modification lost after SetOptions")
+	}
+}
+
+func TestRuleThenOptionsThenParse(t *testing.T) {
+	// The exact pattern from the user report: Rule() before Options().
+	j := Make()
+
+	customVal := ""
+	j.Rule("val", func(rs *RuleSpec) {
+		rs.Close = append([]*AltSpec{{
+			A: func(r *Rule, ctx *Context) {
+				if s, ok := r.Node.(string); ok {
+					customVal = s
+				}
+			},
+			G: "plugin-mod",
+		}}, rs.Close...)
+	})
+
+	// Options change after rule modification — must not lose the modification.
+	yes := true
+	j.SetOptions(Options{
+		Value: &ValueOptions{
+			Lex: &yes,
+			Def: map[string]*ValueDef{
+				"yes": {Val: true},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != "hello" {
+		t.Errorf("expected a:hello, got %v", m)
+	}
+	if customVal != "hello" {
+		t.Errorf("custom rule action should have captured hello, got %q", customVal)
+	}
+}

--- a/go/plugin.go
+++ b/go/plugin.go
@@ -393,11 +393,11 @@ func (j *Jsonic) Derive(opts ...Options) *Jsonic {
 }
 
 // SetOptions deep-merges new options into this instance and rebuilds the
-// config, grammar, and plugins. This matches the TypeScript options() setter
-// behavior: nil/zero fields in opts do not overwrite existing values.
+// config. Existing grammar rules (including plugin modifications) are
+// preserved — matching the TypeScript clone/inherit pattern where
+// options() does not rebuild the grammar.
 // When called from within a plugin (during re-apply), skips plugin
-// re-application to avoid infinite recursion, matching TS behavior where
-// options() does not re-trigger plugins.
+// re-application to avoid infinite recursion.
 // Returns the instance for chaining.
 func (j *Jsonic) SetOptions(opts Options) *Jsonic {
 	merged := Deep(*j.options, opts).(Options)
@@ -412,12 +412,16 @@ func (j *Jsonic) SetOptions(opts Options) *Jsonic {
 	cfg.TinNames = j.parser.Config.TinNames
 	cfg.CustomMatchers = j.parser.Config.CustomMatchers
 
-	j.parser.Config = cfg
+	// Update config in-place to preserve pointer identity.
+	// Grammar closures capture the original *LexConfig pointer, so updating
+	// the object they point to (rather than replacing it) ensures they see
+	// the new config values. This matches TS behavior where configure()
+	// mutates the existing config and parser.clone() inherits the rules.
+	*j.parser.Config = *cfg
 
-	// Rebuild grammar.
-	rsm := make(map[string]*RuleSpec)
-	Grammar(rsm, cfg)
-	j.parser.RSM = rsm
+	// Do NOT rebuild grammar — preserve existing RSM with user rule
+	// modifications. This matches TS where options() calls parser.clone()
+	// which inherits existing rules rather than rebuilding from scratch.
 
 	// Re-apply plugins (with re-entrancy guard to match TS behavior where
 	// options() setter does not re-trigger plugin application).


### PR DESCRIPTION
In TS, options() calls parser.clone() which inherits existing rules. In Go, SetOptions() was rebuilding the grammar from scratch on a fresh RSM, destroying any prior Rule() or Grammar() modifications.

Fix: update the config object in-place (*j.parser.Config = *cfg) instead of replacing the pointer. Grammar closures capture the original *LexConfig pointer, so updating the object they point to ensures they see new config values. The existing RSM is preserved — no grammar rebuild.

This matches the TS pattern where j.rule() then j.options() preserves rule modifications.

Three new tests verify the fix:
- TestSetOptionsPreservesRuleModifications: Rule() then SetOptions()
- TestSetOptionsPreservesGrammarModifications: Grammar() then SetOptions()
- TestRuleThenOptionsThenParse: the exact user-reported pattern

https://claude.ai/code/session_01JRN2i3bkqdW5b4tedbxmLy