### PR TITLE
Unexport internal buildGrammar, keep Grammar() as the public API

### DIFF
--- a/go/grammar.go
+++ b/go/grammar.go
@@ -1,9 +1,9 @@
 package jsonic
 
-// Grammar builds the default jsonic grammar rules using declarative GrammarAltSpec.
+// buildGrammar populates the default jsonic grammar rules using declarative GrammarAltSpec.
 // This is a faithful port of grammar.ts, matching the exact alternate orderings
 // produced by the JSON phase followed by the Jsonic extension phase.
-func Grammar(rsm map[string]*RuleSpec, cfg *LexConfig) {
+func buildGrammar(rsm map[string]*RuleSpec, cfg *LexConfig) {
 	// Named function references for the grammar.
 	// These closures capture cfg for runtime configuration access.
 	ref := map[FuncRef]any{

--- a/go/options.go
+++ b/go/options.go
@@ -320,7 +320,7 @@ func Make(opts ...Options) *Jsonic {
 
 	cfg := buildConfig(&o)
 	rsm := make(map[string]*RuleSpec)
-	Grammar(rsm, cfg)
+	buildGrammar(rsm, cfg)
 
 	maxmul := 3
 	if o.Rule != nil && o.Rule.MaxMul != nil {

--- a/go/parser.go
+++ b/go/parser.go
@@ -51,7 +51,7 @@ type Parser struct {
 func NewParser() *Parser {
 	cfg := DefaultLexConfig()
 	rsm := make(map[string]*RuleSpec)
-	Grammar(rsm, cfg)
+	buildGrammar(rsm, cfg)
 	// Copy global error messages as defaults.
 	msgs := make(map[string]string, len(errorMessages))
 	for k, v := range errorMessages {


### PR DESCRIPTION
Rename the package-level Grammar(rsm, cfg) to buildGrammar() since it's an internal bootstrap function that takes raw rsm/cfg parameters. The public API for declarative grammars is (*Jsonic).Grammar(gs *GrammarSpec) which is what external consumers should use — matching TS jsonic.grammar().

https://claude.ai/code/session_01JRN2i3bkqdW5b4tedbxmLy