### PR TITLE
Guard Go rule-stack growth and add TS↔Go parity review docs

### DIFF
--- a/CODE_REVIEW_TS_GO.md
+++ b/CODE_REVIEW_TS_GO.md
@@ -1,0 +1,75 @@
+# Standard Code Review: TypeScript + Go Implementations
+
+Date: 2026-04-13
+
+This review covers both the canonical TypeScript implementation and the Go port, with parity and general code-quality focus.
+
+## Scope
+
+- TypeScript: `src/parser.ts`, `src/rules.ts`, `src/jsonic.ts`, `src/lexer.ts`.
+- Go: `go/parser.go`, `go/rule.go`, `go/lexer.go`, `go/jsonic.go`.
+- Cross-version alignment tests: `test/alignment.test.js`, `go/alignment_test.go`.
+
+## Executive Summary
+
+- **Overall quality**: solid architecture and strong alignment test infrastructure.
+- **Parity posture**: good baseline coverage, but still has edge-case divergence points.
+- **Most important risk found**: Go rule-stack writes could exceed preallocated capacity under deep/virtual rule churn and panic.
+
+## Findings
+
+### 1) [High] Go rule-stack push could panic on capacity exhaustion
+
+**Where**
+- `go/rule.go` push path writes directly into `ctx.RS[ctx.RSI]`.
+
+**Why it matters**
+- `ctx.RS` is preallocated from an estimate in `go/parser.go`; if the estimate is exceeded, direct indexed writes can panic.
+- TS uses dynamic arrays and does not have this fixed-capacity write hazard.
+
+**Recommendation**
+- Use dynamic growth (`append`) when `ctx.RSI >= len(ctx.RS)`.
+- Keep pop semantics unchanged.
+
+---
+
+### 2) [Medium] TS parse-alternate state uses a shared mutable singleton (`PALT`)
+
+**Where**
+- `src/rules.ts` defines `const PALT = makeAltMatch()` and reuses it in `parse_alts`.
+
+**Why it matters**
+- Reusing a singleton mutable object across parse steps can create subtle reentrancy hazards (e.g., plugin action invoking nested parse).
+- Single-threaded execution reduces risk, but nested parse flows remain possible.
+
+**Recommendation**
+- Prefer allocating a fresh alt-match object per `parse_alts` invocation or pooling with strict ownership guarantees.
+
+---
+
+### 3) [Medium] Documented and actual unmatched-alt behavior differs across TS/Go internals
+
+**Where**
+- TS unmatched-alt path sets parse error token and throws earlier.
+- Go unmatched-alt handling can defer failure to trailing-content checks.
+
+**Why it matters**
+- Error timing/location can differ in edge grammars and plugin-heavy flows.
+
+**Recommendation**
+- Decide whether this is intentional divergence.
+- If intentional: codify with explicit alignment tests + documentation.
+- If not: align Go alt-miss handling with TS parse-time error behavior.
+
+## Positive Notes
+
+- Shared TSV alignment suites are a strong quality mechanism and currently pass in both runtimes.
+- Go has clear, targeted parity tests for option-dependent behavior not expressible in pure TSV.
+- Code organization is readable and mirrors parser phases clearly (lex → rule process → result checks).
+
+## Follow-up Work (Suggested Order)
+
+1. Fix/guard Go rule-stack growth (runtime safety).
+2. Add regression tests for very deep/virtual rule nesting and stack churn.
+3. Decide and codify policy for unmatched-alt behavior parity.
+4. Evaluate TS `PALT` singleton risk and optionally make it per-call state.

--- a/TS_GO_REVIEW.md
+++ b/TS_GO_REVIEW.md
@@ -1,0 +1,84 @@
+# TS ↔ Go Parity Code Review (2026-04-13)
+
+This review treats TypeScript (`src/*.ts`) as canonical and evaluates Go (`go/*.go`) parity.
+
+## Scope reviewed
+
+- TypeScript parser/rule core: `src/parser.ts`, `src/rules.ts`, `src/jsonic.ts`.
+- Go parser/rule core: `go/parser.go`, `go/rule.go`, `go/jsonic.go`.
+- Alignment harness: `test/alignment.test.js`, `go/alignment_test.go`.
+- Stated parity docs: `go/doc/differences.md`.
+
+## High-level assessment
+
+- Shared alignment tests are in place and pass in both implementations.
+- The Go implementation intentionally diverges in some APIs/features.
+- There are still a few parity/documentation gaps worth addressing.
+
+## Findings
+
+### 1) **Behavioral gap:** unmatched alternates become immediate parse errors in TS, but not in Go
+
+**TypeScript behavior**
+
+- In `parse_alts`, if no alternate matches, TS sets an error token (`out.e = ctx.t0`).
+- In `process`, that error token immediately throws `JsonicError`.
+
+**Go behavior**
+
+- `ParseAlts` returns `(nil, false)` when no alternate matches.
+- `Process` does not raise a parse error in that case; it simply continues/pop-closes and relies on later trailing-content checks.
+
+**Impact**
+
+- Potential differences in *when* parse errors are raised and possibly *which token/location* gets reported.
+- Could surface subtle differences under custom grammar/plugin rule sets where fallback/pop behavior differs before EOF checks.
+
+**Recommendation**
+
+- Mirror TS by propagating a parse error token when no alt matches (at least for equivalent rule states), or
+- Add explicit regression alignment tests that lock current Go behavior if divergence is intentional.
+
+---
+
+### 2) **Documentation gap:** stale reference to non-existent detailed differences file
+
+- `go/doc/differences.md` links to `../TS_GO_DIFFERENCES.md`.
+- That file is not present in the repository.
+
+**Impact**
+
+- Broken documentation path for users trying to understand parity status.
+
+**Recommendation**
+
+- Either add the referenced file, or remove/replace the link with an existing canonical document.
+
+---
+
+### 3) **Documentation drift:** stated whitespace short-circuit behavior appears outdated
+
+- `go/doc/differences.md` says Go short-circuits whitespace-only input to `nil`.
+- `go/parser.go` only short-circuits exact empty string (`src == ""`).
+- Whitespace/comment-only handling is otherwise done through normal parse flow (and alignment tests for empty/comment-only pass).
+
+**Impact**
+
+- Misleading docs for contributors auditing parity behavior.
+
+**Recommendation**
+
+- Update wording to distinguish empty-string fast path vs whitespace/comment handling through parse pipeline.
+
+## Positive parity signals
+
+- Shared TSV alignment suites exist for: values, safe-key, map-merge, number-text, structure, empty, errors.
+- TS and Go both run these and currently pass.
+- Go also includes additional direct parity tests for option-dependent behavior not easily represented in TSV.
+
+## Suggested next parity work (priority order)
+
+1. Resolve unmatched-alt error propagation parity (or codify intentional divergence in tests/docs).
+2. Fix broken documentation link to detailed differences.
+3. Correct stale wording around empty/whitespace handling.
+4. Keep extending shared TSV coverage for plugin/modifier edge cases.

--- a/go/doc/differences.md
+++ b/go/doc/differences.md
@@ -4,9 +4,6 @@ The TypeScript version is the authoritative implementation. The Go version is
 a faithful port but has some differences in behavior, missing features, and
 Go-specific additions.
 
-For the detailed, line-by-line analysis, see
-[TS_GO_DIFFERENCES.md](../TS_GO_DIFFERENCES.md).
-
 ## Behavioral Differences
 
 These affect parse output for the same input.
@@ -23,8 +20,9 @@ but is rejected as not-a-number in Go (treated as text).
 
 ### Empty / Whitespace Input
 
-TypeScript processes whitespace-only strings through the full parse flow.
-Go short-circuits whitespace-only input to `nil`.
+Both implementations short-circuit exact empty-string input (`""`).
+Whitespace/comment-only input is processed through the normal parse flow in both
+implementations and resolves to `null`/`nil` by grammar behavior.
 
 ### Token Consumption
 

--- a/go/rule.go
+++ b/go/rule.go
@@ -87,22 +87,22 @@ func CGte(val int) CondOp { return CondOp{Op: "$gte", Val: val} }
 
 // AltSpec defines a parse alternate specification.
 type AltSpec struct {
-	S [][]Tin         // Token Tin sequences to match: s[0] for t0, s[1] for t1
-	P string          // Push rule name (create child)
-	R string          // Replace rule name (create sibling)
-	B int             // Move token pointer backward (backtrack)
-	C  AltCond         // Custom condition (function)
-	CD map[string]any  // Declarative condition (converted to C by NormAlt)
-	N  map[string]int  // Counter increments
-	A AltAction       // Match action
-	U map[string]any  // Custom props added to Rule.u
-	K map[string]any  // Custom props added to Rule.k (propagated)
-	G string          // Named group tags (comma-separated)
-	H AltModifier     // Alt modifier (called after match to potentially modify the alt)
-	E AltError        // Error generation
-	PF func(r *Rule, ctx *Context) string  // Dynamic push rule name
-	RF func(r *Rule, ctx *Context) string  // Dynamic replace rule name
-	BF func(r *Rule, ctx *Context) int     // Dynamic backtrack
+	S  [][]Tin                            // Token Tin sequences to match: s[0] for t0, s[1] for t1
+	P  string                             // Push rule name (create child)
+	R  string                             // Replace rule name (create sibling)
+	B  int                                // Move token pointer backward (backtrack)
+	C  AltCond                            // Custom condition (function)
+	CD map[string]any                     // Declarative condition (converted to C by NormAlt)
+	N  map[string]int                     // Counter increments
+	A  AltAction                          // Match action
+	U  map[string]any                     // Custom props added to Rule.u
+	K  map[string]any                     // Custom props added to Rule.k (propagated)
+	G  string                             // Named group tags (comma-separated)
+	H  AltModifier                        // Alt modifier (called after match to potentially modify the alt)
+	E  AltError                           // Error generation
+	PF func(r *Rule, ctx *Context) string // Dynamic push rule name
+	RF func(r *Rule, ctx *Context) string // Dynamic replace rule name
+	BF func(r *Rule, ctx *Context) int    // Dynamic backtrack
 }
 
 // RuleSpec defines the specification for a parsing rule.
@@ -154,8 +154,8 @@ func (rs *RuleSpec) PrependClose(alts ...*AltSpec) *RuleSpec {
 // AltModListOpts configures modifications for RuleSpec alternate lists.
 // Matches the TS ListMods parameter to rs.open(alts, mods)/rs.close(alts, mods).
 type AltModListOpts struct {
-	Delete []int                         // Indices to delete (supports negative).
-	Move   []int                         // Pairs: [from, to, from, to, ...].
+	Delete []int                            // Indices to delete (supports negative).
+	Move   []int                            // Pairs: [from, to, from, to, ...].
 	Custom func(list []*AltSpec) []*AltSpec // Custom modification callback.
 }
 
@@ -497,7 +497,11 @@ func (r *Rule) Process(ctx *Context, lex *Lex) *Rule {
 		if pushName != "" {
 			rulespec, ok := ctx.RSM[pushName]
 			if ok {
-				ctx.RS[ctx.RSI] = r
+				if ctx.RSI < len(ctx.RS) {
+					ctx.RS[ctx.RSI] = r
+				} else {
+					ctx.RS = append(ctx.RS, r)
+				}
 				ctx.RSI++
 				next = MakeRule(rulespec, ctx, r.Node)
 				r.Child = next


### PR DESCRIPTION
### Motivation

- Prevent runtime panics in the Go parser when rule-stack preallocation is exceeded by using safe dynamic growth. 
- Improve parity documentation and capture findings from a cross-implementation code review for TypeScript and Go. 

### Description

- Change the Go rule push path in `go/rule.go` to check `ctx.RSI` against `len(ctx.RS)` and use `append` to grow `ctx.RS` when needed, avoiding direct out-of-bounds writes. 
- Clean up `AltSpec` and `AltModListOpts` field formatting/comments in `go/rule.go` (non-functional whitespace/comment adjustments). 
- Add a detailed code-review document `CODE_REVIEW_TS_GO.md` that summarizes parity findings and recommended follow-ups. 
- Add `TS_GO_REVIEW.md` with focused TS↔Go parity notes, behavioral gaps, and suggested next steps, and update `go/doc/differences.md` to correct wording around empty/whitespace handling and remove a stale link. 

### Testing

- Ran shared TSV alignment suites referenced in the review against both runtimes and they passed. 
- Built and ran Go unit tests (`go test ./...`) and the targeted parser/alignment tests, which succeeded. 
- Ran JavaScript alignment tests (`npm test` / `yarn test` for `test/alignment.test.js`) and they continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb8ea9a20832a8422248e96125d5d)