### PR TITLE
Add regexp support for grammar options and custom matchers

### DIFF
--- a/go/grammar_decl_test.go
+++ b/go/grammar_decl_test.go
@@ -1409,6 +1409,42 @@ func TestMatchTokenNilRegexpNoPanic(t *testing.T) {
 	}
 }
 
+// TestValueDefReUsesValWhenValFuncNil verifies that regex-based value.def
+// entries return ValueDef.Val (not the matched source text) when ValFunc is nil.
+func TestValueDefReUsesValWhenValFuncNil(t *testing.T) {
+	j := Make()
+	lex := true
+	mustGrammar(t, j, &GrammarSpec{
+		Options: &Options{
+			Value: &ValueOptions{
+				Lex: &lex,
+				Def: map[string]*ValueDef{
+					"yes": {
+						Val:   true,
+						Match: regexp.MustCompile(`(?i)^yes$`),
+					},
+					"no": {
+						Val:   false,
+						Match: regexp.MustCompile(`(?i)^no$`),
+					},
+				},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:YES,b:No")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != true {
+		t.Errorf("expected a:true, got %v (%T)", m["a"], m["a"])
+	}
+	if m["b"] != false {
+		t.Errorf("expected b:false, got %v (%T)", m["b"], m["b"])
+	}
+}
+
 // TestMatchValueNilSpecNoPanic verifies that nil entries in Match.Value
 // are skipped rather than causing a nil-pointer panic in buildConfig.
 func TestMatchValueNilSpecNoPanic(t *testing.T) {

--- a/go/grammar_decl_test.go
+++ b/go/grammar_decl_test.go
@@ -1380,3 +1380,27 @@ func TestResolveFuncRefsRegexInSlice(t *testing.T) {
 		t.Errorf("[2] expected @at, got %v", result[2])
 	}
 }
+
+// TestMatchValueNilSpecNoPanic verifies that nil entries in Match.Value
+// are skipped rather than causing a nil-pointer panic in buildConfig.
+func TestMatchValueNilSpecNoPanic(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Options: &Options{
+			Match: &MatchOptions{
+				Value: map[string]*MatchValueSpec{
+					"x": nil,
+				},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != float64(1) {
+		t.Errorf("expected a:1, got %v", m["a"])
+	}
+}

--- a/go/grammar_decl_test.go
+++ b/go/grammar_decl_test.go
@@ -858,3 +858,525 @@ func TestRuleThenOptionsThenParse(t *testing.T) {
 		t.Errorf("custom rule action should have captured hello, got %q", customVal)
 	}
 }
+
+// === Regexp support tests (parity with TS grammar.test.js) ===
+
+// TestGrammarRegexNumberExclude mirrors TS "options-regex-number-exclude".
+// Uses @/…/ in OptionsMap to specify a RegExp for number.exclude.
+// Uses ^0[0-9]+$ which correctly matches leading-zero numbers like "01".
+func TestGrammarRegexNumberExclude(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		OptionsMap: map[string]any{
+			"number": map[string]any{
+				"exclude": "@/^0[0-9]+$/",
+			},
+		},
+	})
+
+	result, err := j.Parse("a:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != float64(0) {
+		t.Errorf("expected a:0, got %v", m["a"])
+	}
+
+	result, err = j.Parse("a:01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != "01" {
+		t.Errorf("expected a:'01' (text), got %v (%T)", m["a"], m["a"])
+	}
+
+	result, err = j.Parse("a:123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != float64(123) {
+		t.Errorf("expected a:123, got %v", m["a"])
+	}
+}
+
+// TestGrammarRegexNumberExcludeTyped tests number.exclude with a *regexp.Regexp
+// via the typed Options API (not OptionsMap).
+func TestGrammarRegexNumberExcludeTyped(t *testing.T) {
+	re := regexp.MustCompile(`^0[0-9]+$`)
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Options: &Options{
+			Number: &NumberOptions{
+				Exclude: func(s string) bool {
+					return re.MatchString(s)
+				},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != "01" {
+		t.Errorf("expected a:'01' (text), got %v (%T)", m["a"], m["a"])
+	}
+}
+
+// TestGrammarRegexValueMatch mirrors TS "options-regex-value-match".
+// Uses @/…/ in value.def with a FuncRef val for regex-matched values.
+func TestGrammarRegexValueMatch(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Ref: map[FuncRef]any{
+			"@valOn":  func(match []string) any { return true },
+			"@valOff": func(match []string) any { return false },
+		},
+		OptionsMap: map[string]any{
+			"value": map[string]any{
+				"def": map[string]any{
+					"on":  map[string]any{"val": "@valOn", "match": "@/^on$/i"},
+					"off": map[string]any{"val": "@valOff", "match": "@/^off$/i"},
+				},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:ON,b:Off,c:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != true {
+		t.Errorf("expected a:true, got %v", m["a"])
+	}
+	if m["b"] != false {
+		t.Errorf("expected b:false, got %v", m["b"])
+	}
+	if m["c"] != float64(1) {
+		t.Errorf("expected c:1, got %v", m["c"])
+	}
+
+	result, err = j.Parse("a:on,b:OFF")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != true {
+		t.Errorf("expected a:true, got %v", m["a"])
+	}
+	if m["b"] != false {
+		t.Errorf("expected b:false, got %v", m["b"])
+	}
+}
+
+// TestGrammarRegexValueMatchTyped tests value.def Match via typed API.
+func TestGrammarRegexValueMatchTyped(t *testing.T) {
+	j := Make()
+	lex := true
+	mustGrammar(t, j, &GrammarSpec{
+		Options: &Options{
+			Value: &ValueOptions{
+				Lex: &lex,
+				Def: map[string]*ValueDef{
+					"on": {
+						Match:   regexp.MustCompile(`(?i)^on$`),
+						ValFunc: func(m []string) any { return true },
+					},
+					"off": {
+						Match:   regexp.MustCompile(`(?i)^off$`),
+						ValFunc: func(m []string) any { return false },
+					},
+				},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:ON,b:Off")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != true {
+		t.Errorf("expected a:true, got %v", m["a"])
+	}
+	if m["b"] != false {
+		t.Errorf("expected b:false, got %v", m["b"])
+	}
+}
+
+// TestGrammarRegexWithFlags mirrors TS "options-regex-with-flags".
+func TestGrammarRegexWithFlags(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Ref: map[FuncRef]any{
+			"@valYes": func(match []string) any { return "YES!" },
+		},
+		OptionsMap: map[string]any{
+			"value": map[string]any{
+				"def": map[string]any{
+					"yes": map[string]any{"val": "@valYes", "match": "@/^yes$/i"},
+				},
+			},
+		},
+	})
+
+	// The /i flag makes it case-insensitive.
+	result, err := j.Parse("a:YES")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != "YES!" {
+		t.Errorf("expected a:YES!, got %v", m["a"])
+	}
+
+	result, err = j.Parse("a:Yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != "YES!" {
+		t.Errorf("expected a:YES!, got %v", m["a"])
+	}
+
+	result, err = j.Parse("a:yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != "YES!" {
+		t.Errorf("expected a:YES!, got %v", m["a"])
+	}
+}
+
+// TestGrammarRegexNoFlags mirrors TS "options-regex-no-flags".
+func TestGrammarRegexNoFlags(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		OptionsMap: map[string]any{
+			"number": map[string]any{
+				"exclude": "@/^0[0-9]+$/",
+			},
+		},
+	})
+
+	result, err := j.Parse("a:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != float64(0) {
+		t.Errorf("expected a:0, got %v", m["a"])
+	}
+
+	result, err = j.Parse("a:42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != float64(42) {
+		t.Errorf("expected a:42, got %v", m["a"])
+	}
+
+	result, err = j.Parse("a:01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != "01" {
+		t.Errorf("expected a:'01' (text), got %v (%T)", m["a"], m["a"])
+	}
+}
+
+// TestGrammarRegexMixedWithFuncref mirrors TS "options-regex-mixed-with-funcref".
+func TestGrammarRegexMixedWithFuncref(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Ref: map[FuncRef]any{
+			"@prepend": func(prev, curr any, r *Rule, ctx *Context) any {
+				ps, pok := prev.(string)
+				cs, cok := curr.(string)
+				if pok && cok {
+					return ps + cs
+				}
+				return curr
+			},
+		},
+		OptionsMap: map[string]any{
+			"map": map[string]any{
+				"merge": "@prepend",
+			},
+			"number": map[string]any{
+				"exclude": "@/^0[0-9]+$/",
+			},
+		},
+	})
+
+	// FuncRef merge: duplicate keys concatenate.
+	result, err := j.Parse("a:x,a:y")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != "xy" {
+		t.Errorf("expected a:xy, got %v", m["a"])
+	}
+
+	// RegExp exclude: leading-zero numbers become text.
+	result, err = j.Parse("a:007")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != "007" {
+		t.Errorf("expected a:'007' (text), got %v (%T)", m["a"], m["a"])
+	}
+
+	result, err = j.Parse("a:42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["a"] != float64(42) {
+		t.Errorf("expected a:42, got %v", m["a"])
+	}
+}
+
+// TestGrammarRegexInArray mirrors TS "options-regex-in-array".
+// @/…/ resolution should work inside arrays (ResolveFuncRefs recurses into slices).
+func TestGrammarRegexInArray(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Ref: map[FuncRef]any{
+			"@valT": func(match []string) any { return true },
+			"@valF": func(match []string) any { return false },
+		},
+		OptionsMap: map[string]any{
+			"value": map[string]any{
+				"def": map[string]any{
+					"t": map[string]any{"val": "@valT", "match": "@/^t$/i"},
+					"f": map[string]any{"val": "@valF", "match": "@/^f$/i"},
+				},
+			},
+		},
+	})
+
+	result, err := j.Parse("[T, F, 1]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	arr := result.([]any)
+	if len(arr) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(arr))
+	}
+	if arr[0] != true {
+		t.Errorf("expected [0]=true, got %v", arr[0])
+	}
+	if arr[1] != false {
+		t.Errorf("expected [1]=false, got %v", arr[1])
+	}
+	if arr[2] != float64(1) {
+		t.Errorf("expected [2]=1, got %v", arr[2])
+	}
+}
+
+// TestGrammarRegexEscapeAtPrefix mirrors TS "options-escape-at-regex-like".
+// @@ prevents @/…/ from being interpreted as a regex.
+func TestGrammarRegexEscapeAtPrefix(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		OptionsMap: map[string]any{
+			"tag": "@@/not-a-regex/",
+		},
+	})
+
+	if j.Options().Tag != "@/not-a-regex/" {
+		t.Errorf("expected @/not-a-regex/, got %v", j.Options().Tag)
+	}
+}
+
+// TestGrammarRegexMatchToken mirrors TS "options-regex-match-token".
+// Uses @/…/ to specify a RegExp for a custom match token.
+func TestGrammarRegexMatchToken(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		OptionsMap: map[string]any{
+			"match": map[string]any{
+				"token": map[string]any{
+					"#ID": "@/^[a-zA-Z_][a-zA-Z_0-9]*/",
+				},
+			},
+			"tokenSet": map[string]any{
+				"KEY": []any{"#ST", "#ID"},
+				"VAL": []any{"#TX", "#NR", "#ST", "#VL", "#ID"},
+			},
+		},
+	})
+
+	// 'a' matches #ID and #ID is in KEY, so a:1 parses as a pair.
+	result, err := j.Parse("a:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != float64(1) {
+		t.Errorf("expected a:1, got %v", m["a"])
+	}
+
+	result, err = j.Parse("foo:bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = result.(map[string]any)
+	if m["foo"] != "bar" {
+		t.Errorf("expected foo:bar, got %v", m["foo"])
+	}
+}
+
+// TestGrammarRegexMatchTokenTyped tests match.token via typed Options API.
+func TestGrammarRegexMatchTokenTyped(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Options: &Options{
+			Match: &MatchOptions{
+				Token: map[string]*regexp.Regexp{
+					"#ID": regexp.MustCompile(`^[a-zA-Z_][a-zA-Z_0-9]*`),
+				},
+			},
+			TokenSet: map[string][]string{
+				"KEY": {"#ST", "#ID"},
+				"VAL": {"#TX", "#NR", "#ST", "#VL", "#ID"},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != float64(1) {
+		t.Errorf("expected a:1, got %v", m["a"])
+	}
+}
+
+// TestGrammarRegexMatchValue tests match.value via OptionsMap (declarative form).
+// Note: match.value runs against the forward source (remaining input), so regexps
+// should NOT use $ anchor. Use value.def[name].match for extracted-text matching.
+func TestGrammarRegexMatchValue(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Ref: map[FuncRef]any{
+			"@valOn":  func(match []string) any { return true },
+			"@valOff": func(match []string) any { return false },
+		},
+		OptionsMap: map[string]any{
+			"match": map[string]any{
+				"value": map[string]any{
+					// No $ anchor — matches against forward source, not extracted text.
+					"on":  map[string]any{"match": "@/^on/i", "val": "@valOn"},
+					"off": map[string]any{"match": "@/^off/i", "val": "@valOff"},
+				},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:ON,b:off")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != true {
+		t.Errorf("expected a:true, got %v", m["a"])
+	}
+	if m["b"] != false {
+		t.Errorf("expected b:false, got %v", m["b"])
+	}
+}
+
+// TestGrammarRegexMatchValueTyped tests match.value via typed Options API.
+func TestGrammarRegexMatchValueTyped(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Options: &Options{
+			Match: &MatchOptions{
+				Value: map[string]*MatchValueSpec{
+					"on": {
+						Match: regexp.MustCompile(`(?i)^on`),
+						Val:   func(m []string) any { return true },
+					},
+					"off": {
+						Match: regexp.MustCompile(`(?i)^off`),
+						Val:   func(m []string) any { return false },
+					},
+				},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:ON,b:off")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != true {
+		t.Errorf("expected a:true, got %v", m["a"])
+	}
+	if m["b"] != false {
+		t.Errorf("expected b:false, got %v", m["b"])
+	}
+}
+
+// TestResolveFuncRefsRegexInNestedMap verifies @/…/ resolution in nested structures.
+func TestResolveFuncRefsRegexInNestedMap(t *testing.T) {
+	input := map[string]any{
+		"number": map[string]any{
+			"exclude": "@/^0[0-9]+/",
+		},
+		"value": map[string]any{
+			"def": map[string]any{
+				"on": map[string]any{
+					"match": "@/^on$/i",
+				},
+			},
+		},
+	}
+	result := ResolveFuncRefs(input, nil).(map[string]any)
+
+	num := result["number"].(map[string]any)
+	if _, ok := num["exclude"].(*regexp.Regexp); !ok {
+		t.Errorf("number.exclude should be *regexp.Regexp, got %T", num["exclude"])
+	}
+
+	val := result["value"].(map[string]any)
+	def := val["def"].(map[string]any)
+	on := def["on"].(map[string]any)
+	if _, ok := on["match"].(*regexp.Regexp); !ok {
+		t.Errorf("value.def.on.match should be *regexp.Regexp, got %T", on["match"])
+	}
+}
+
+// TestResolveFuncRefsRegexInSlice verifies @/…/ resolution inside slices.
+func TestResolveFuncRefsRegexInSlice(t *testing.T) {
+	input := []any{"@/^test$/i", "@SKIP", "@@at"}
+	result := ResolveFuncRefs(input, nil).([]any)
+
+	if _, ok := result[0].(*regexp.Regexp); !ok {
+		t.Errorf("[0] should be *regexp.Regexp, got %T", result[0])
+	}
+	re := result[0].(*regexp.Regexp)
+	if !re.MatchString("TEST") {
+		t.Error("regex should match TEST (case insensitive)")
+	}
+	if !IsSkip(result[1]) {
+		t.Errorf("[1] should be Skip, got %v", result[1])
+	}
+	if result[2] != "@at" {
+		t.Errorf("[2] expected @at, got %v", result[2])
+	}
+}

--- a/go/grammar_decl_test.go
+++ b/go/grammar_decl_test.go
@@ -1381,6 +1381,34 @@ func TestResolveFuncRefsRegexInSlice(t *testing.T) {
 	}
 }
 
+// TestMatchTokenNilRegexpNoPanic verifies that a nil *regexp.Regexp entry
+// in Match.Token is skipped during parsing instead of causing a panic.
+func TestMatchTokenNilRegexpNoPanic(t *testing.T) {
+	j := Make()
+	mustGrammar(t, j, &GrammarSpec{
+		Options: &Options{
+			Match: &MatchOptions{
+				Token: map[string]*regexp.Regexp{
+					"#ID": nil,
+				},
+			},
+			TokenSet: map[string][]string{
+				"KEY": {"#ST", "#ID"},
+				"VAL": {"#TX", "#NR", "#ST", "#VL", "#ID"},
+			},
+		},
+	})
+
+	result, err := j.Parse("a:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != float64(1) {
+		t.Errorf("expected a:1, got %v", m["a"])
+	}
+}
+
 // TestMatchValueNilSpecNoPanic verifies that nil entries in Match.Value
 // are skipped rather than causing a nil-pointer panic in buildConfig.
 func TestMatchValueNilSpecNoPanic(t *testing.T) {

--- a/go/lexer.go
+++ b/go/lexer.go
@@ -453,6 +453,9 @@ func (l *Lex) matchMatch(rule *Rule) *Token {
 		}
 
 		for tin, re := range l.Config.MatchTokens {
+			if re == nil {
+				continue
+			}
 			// Check if this Tin is expected at position 0 in any alt.
 			expected := false
 			for _, alt := range alts {

--- a/go/lexer.go
+++ b/go/lexer.go
@@ -1,9 +1,16 @@
 package jsonic
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 )
+
+// MatchValueEntry holds a resolved match.value matcher entry.
+type MatchValueEntry struct {
+	Match *regexp.Regexp
+	Val   func([]string) any
+}
 
 // Lex is the lexer that produces tokens from source text.
 type Lex struct {
@@ -48,6 +55,15 @@ type LexConfig struct {
 	// Value definitions: keyword → value (e.g. "true" → true)
 	// If nil, uses built-in defaults (true, false, null).
 	ValueDef map[string]any
+
+	// ValueDefRe holds regex-processed value definitions (TS: cfg.value.defre).
+	// These are value defs with a Match regexp, checked after exact matches fail.
+	ValueDefRe map[string]*ValueDef
+
+	// Match options (TS: cfg.match)
+	MatchLex          bool                          // Enable custom matching. Default: false.
+	MatchTokens       map[Tin]*regexp.Regexp         // Custom token tin → regexp.
+	MatchValues       []*MatchValueEntry             // Custom value matchers.
 
 	// Number options
 	NumberExclude func(string) bool // Exclude certain number-like strings.
@@ -313,7 +329,14 @@ func (l *Lex) nextRaw(rule *Rule) *Token {
 	}
 
 	// Try matchers in order (matching TS lex.match ordering):
-	// custom(<2e6), fixed(2e6), space(3e6), line(4e6), string(5e6), comment(6e6), number(7e6), text(8e6)
+	// match(1e6), custom(<2e6), fixed(2e6), space(3e6), line(4e6), string(5e6), comment(6e6), number(7e6), text(8e6)
+
+	// Match matcher (priority 1e6) — regexp-based token and value matching.
+	if l.Config.MatchLex {
+		if tkn := l.matchMatch(rule); tkn != nil {
+			return tkn
+		}
+	}
 
 	// Run custom matchers with priority < 2000000 (before fixed).
 	for _, m := range l.Config.CustomMatchers {
@@ -386,6 +409,73 @@ func (l *Lex) nextRaw(rule *Rule) *Token {
 	}
 
 	// No matcher matched
+	return nil
+}
+
+// matchMatch implements the match matcher (TS: makeMatchMatcher at priority 1e6).
+// Handles both match.value (regexp → #VL) and match.token (regexp → custom token).
+func (l *Lex) matchMatch(rule *Rule) *Token {
+	if l.pnt.SI >= l.pnt.Len {
+		return nil
+	}
+
+	fwd := l.Src[l.pnt.SI:]
+
+	// Match values first (TS: valueMatchers loop).
+	for _, vm := range l.Config.MatchValues {
+		if vm.Match != nil {
+			res := vm.Match.FindStringSubmatch(fwd)
+			if res != nil && len(res[0]) > 0 {
+				msrc := res[0]
+				mlen := len(msrc)
+				var val any
+				if vm.Val != nil {
+					val = vm.Val(res)
+				} else {
+					val = msrc
+				}
+				tkn := l.Token("#VL", TinVL, val, msrc)
+				l.pnt.SI += mlen
+				l.pnt.CI += mlen
+				return tkn
+			}
+		}
+	}
+
+	// Match tokens (TS: tokenMatchers loop).
+	// Only match if the token type is expected in the current rule position.
+	if rule != nil && rule.Spec != nil {
+		var alts []*AltSpec
+		if rule.State == OPEN {
+			alts = rule.Spec.Open
+		} else {
+			alts = rule.Spec.Close
+		}
+
+		for tin, re := range l.Config.MatchTokens {
+			// Check if this Tin is expected at position 0 in any alt.
+			expected := false
+			for _, alt := range alts {
+				if len(alt.S) > 0 && tinMatch(tin, alt.S[0]) {
+					expected = true
+					break
+				}
+			}
+			if !expected {
+				continue
+			}
+
+			res := re.FindString(fwd)
+			if res != "" {
+				name := l.tinNameFor(tin)
+				tkn := l.Token(name, tin, res, res)
+				l.pnt.SI += len(res)
+				l.pnt.CI += len(res)
+				return tkn
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -1111,12 +1201,40 @@ func (l *Lex) matchText() *Token {
 	// Check for value keywords
 	if l.Config.ValueLex {
 		if l.Config.ValueDef != nil {
-			// Custom value definitions
+			// Custom value definitions (exact match)
 			if val, ok := l.Config.ValueDef[msrc]; ok {
 				tkn := l.Token("#VL", TinVL, val, msrc)
 				l.pnt.SI += mlen
 				l.pnt.CI += mlen
 				return tkn
+			}
+
+			// Regex-processed value definitions (TS: cfg.value.defre)
+			if len(l.Config.ValueDefRe) > 0 {
+				for _, vspec := range l.Config.ValueDefRe {
+					if vspec.Match != nil {
+						var matchSrc string
+						if vspec.Consume {
+							matchSrc = src[start:]
+						} else {
+							matchSrc = msrc
+						}
+						res := vspec.Match.FindStringSubmatch(matchSrc)
+						if res != nil && (vspec.Consume || len(res[0]) == len(msrc)) {
+							remsrc := res[0]
+							var val any
+							if vspec.ValFunc != nil {
+								val = vspec.ValFunc(res)
+							} else {
+								val = remsrc
+							}
+							tkn := l.Token("#VL", TinVL, val, remsrc)
+							l.pnt.SI = start + len(remsrc)
+							l.pnt.CI += len(remsrc)
+							return tkn
+						}
+					}
+				}
 			}
 		} else {
 			// Default value keywords (matching TS: true, false, null only)

--- a/go/lexer.go
+++ b/go/lexer.go
@@ -1228,6 +1228,8 @@ func (l *Lex) matchText() *Token {
 							var val any
 							if vspec.ValFunc != nil {
 								val = vspec.ValFunc(res)
+							} else if vspec.Val != nil {
+								val = vspec.Val
 							} else {
 								val = remsrc
 							}

--- a/go/options.go
+++ b/go/options.go
@@ -1,6 +1,9 @@
 package jsonic
 
-import "strconv"
+import (
+	"regexp"
+	"strconv"
+)
 
 // Options configures a Jsonic parser instance.
 // All fields use pointer types so that nil means "use default".
@@ -11,6 +14,14 @@ type Options struct {
 
 	// Fixed controls fixed token recognition ({, }, [, ], :, ,).
 	Fixed *FixedOptions
+
+	// Match controls custom regexp-based token and value matching.
+	// Matches TS options.match.
+	Match *MatchOptions
+
+	// TokenSet allows customizing token sets (VAL, KEY, etc.).
+	// Matches TS options.tokenSet.
+	TokenSet map[string][]string
 
 	// Space controls space/tab lexing.
 	Space *SpaceOptions
@@ -99,6 +110,21 @@ type PropertyOptions struct {
 	// When true, map values include an Implicit flag indicating whether
 	// the map was created implicitly (without braces). Default: false.
 	MapRef *bool
+}
+
+// MatchOptions controls custom regexp-based matching.
+// Matches TS options.match.
+type MatchOptions struct {
+	Lex   *bool                           // Enable custom matching. Default: true.
+	Token map[string]*regexp.Regexp        // "#NAME" → regexp pattern for custom tokens.
+	Value map[string]*MatchValueSpec       // name → {Match, Val} for custom value matchers.
+}
+
+// MatchValueSpec defines a regexp-based value matcher.
+// Matches TS options.match.value[name].
+type MatchValueSpec struct {
+	Match *regexp.Regexp       // Regexp pattern to match against.
+	Val   func([]string) any   // Optional value transformer, receives match groups.
 }
 
 // SafeOptions controls key safety.
@@ -192,6 +218,20 @@ type ListOptions struct {
 // ValueDef defines a keyword value.
 type ValueDef struct {
 	Val any // Value to produce for this keyword.
+
+	// Match is a RegExp pattern for regex-based value matching.
+	// When set, the value keyword is matched by regex instead of exact string.
+	// Matches TS options.value.def[name].match.
+	Match *regexp.Regexp
+
+	// ValFunc is a function that produces the value from regex match groups.
+	// Used when Match is set and the value depends on the match result.
+	// Matches TS value.def[name].val when val is a function.
+	ValFunc func(match []string) any
+
+	// Consume, when true, matches against the full forward source (not just
+	// the text token). The regexp should start with ^.
+	Consume bool
 }
 
 // ValueOptions controls keyword value matching.
@@ -497,6 +537,22 @@ func buildConfig(o *Options) *LexConfig {
 	// Fixed tokens
 	cfg.FixedLex = boolVal(optBool(o.Fixed, func(f *FixedOptions) *bool { return f.Lex }), true)
 
+	// Match (custom regexp matchers - TS: options.match)
+	// Always initialize maps so SetOptions can add entries later.
+	cfg.MatchTokens = make(map[Tin]*regexp.Regexp)
+	if o.Match != nil {
+		cfg.MatchLex = boolVal(o.Match.Lex, true)
+		if o.Match.Value != nil {
+			cfg.MatchValues = make([]*MatchValueEntry, 0, len(o.Match.Value))
+			for _, spec := range o.Match.Value {
+				cfg.MatchValues = append(cfg.MatchValues, &MatchValueEntry{
+					Match: spec.Match,
+					Val:   spec.Val,
+				})
+			}
+		}
+	}
+
 	// Space
 	cfg.SpaceLex = boolVal(optBool(o.Space, func(s *SpaceOptions) *bool { return s.Lex }), true)
 	if o.Space != nil && o.Space.Chars != "" {
@@ -614,9 +670,15 @@ func buildConfig(o *Options) *LexConfig {
 	cfg.ValueLex = boolVal(optBool(o.Value, func(v *ValueOptions) *bool { return v.Lex }), true)
 	if o.Value != nil && o.Value.Def != nil {
 		cfg.ValueDef = make(map[string]any)
+		cfg.ValueDefRe = make(map[string]*ValueDef)
 		for k, v := range o.Value.Def {
 			if v != nil {
-				cfg.ValueDef[k] = v.Val
+				if v.Match != nil {
+					// Regex-based value def goes into ValueDefRe (TS: cfg.value.defre)
+					cfg.ValueDefRe[k] = v
+				} else {
+					cfg.ValueDef[k] = v.Val
+				}
 			}
 		}
 	}

--- a/go/options.go
+++ b/go/options.go
@@ -545,6 +545,9 @@ func buildConfig(o *Options) *LexConfig {
 		if o.Match.Value != nil {
 			cfg.MatchValues = make([]*MatchValueEntry, 0, len(o.Match.Value))
 			for _, spec := range o.Match.Value {
+				if spec == nil {
+					continue
+				}
 				cfg.MatchValues = append(cfg.MatchValues, &MatchValueEntry{
 					Match: spec.Match,
 					Val:   spec.Val,

--- a/go/plugin.go
+++ b/go/plugin.go
@@ -450,6 +450,15 @@ func (j *Jsonic) SetOptions(opts Options) *Jsonic {
 	cfg.FixedSorted = j.parser.Config.FixedSorted
 	cfg.TinNames = j.parser.Config.TinNames
 	cfg.CustomMatchers = j.parser.Config.CustomMatchers
+	// Preserve match token/value entries added by prior SetOptions/Grammar calls.
+	if len(j.parser.Config.MatchTokens) > 0 {
+		for k, v := range j.parser.Config.MatchTokens {
+			cfg.MatchTokens[k] = v
+		}
+	}
+	if len(j.parser.Config.MatchValues) > 0 {
+		cfg.MatchValues = append(cfg.MatchValues, j.parser.Config.MatchValues...)
+	}
 
 	// Update config in-place to preserve pointer identity.
 	// Grammar closures capture the original *LexConfig pointer, so updating
@@ -477,6 +486,29 @@ func (j *Jsonic) SetOptions(opts Options) *Jsonic {
 		for name, spec := range opts.Lex.Match {
 			matcher := spec.Make(j.parser.Config, j.options)
 			j.AddMatcher(name, spec.Order, matcher)
+		}
+	}
+
+	// Apply match.token: resolve token names to Tins and register regexp matchers.
+	if opts.Match != nil && opts.Match.Token != nil {
+		for name, re := range opts.Match.Token {
+			tin := j.Token(name)
+			j.parser.Config.MatchTokens[tin] = re
+		}
+	}
+
+	// Apply tokenSet: resolve token names and update per-instance sets.
+	if opts.TokenSet != nil {
+		for setName, names := range opts.TokenSet {
+			var tins []Tin
+			for _, name := range names {
+				if name == "" {
+					continue
+				}
+				resolved := j.resolveTokenName(name)
+				tins = append(tins, resolved...)
+			}
+			j.SetTokenSet(setName, tins)
 		}
 	}
 

--- a/go/utility.go
+++ b/go/utility.go
@@ -636,6 +636,16 @@ func MapToOptions(m map[string]any) Options {
 					vd := &ValueDef{}
 					if val, ok := vv["val"]; ok {
 						vd.Val = val
+						// If val is a function, store it as ValFunc for regex matches.
+						if fn, ok := val.(func([]string) any); ok {
+							vd.ValFunc = fn
+						}
+					}
+					if m, ok := vv["match"].(*regexp.Regexp); ok {
+						vd.Match = m
+					}
+					if c, ok := vv["consume"].(bool); ok {
+						vd.Consume = c
 					}
 					opts.Value.Def[k] = vd
 				case nil, bool:
@@ -661,6 +671,10 @@ func MapToOptions(m map[string]any) Options {
 		}
 		if fn, ok := nm["exclude"].(func(string) bool); ok {
 			opts.Number.Exclude = fn
+		} else if re, ok := nm["exclude"].(*regexp.Regexp); ok {
+			opts.Number.Exclude = func(s string) bool {
+				return re.MatchString(s)
+			}
 		}
 	}
 
@@ -717,6 +731,57 @@ func MapToOptions(m map[string]any) Options {
 		opts.Safe = &SafeOptions{}
 		if key, ok := safe["key"].(bool); ok {
 			opts.Safe.Key = &key
+		}
+	}
+
+	// Match options (TS: options.match)
+	if mm, ok := m["match"].(map[string]any); ok {
+		opts.Match = &MatchOptions{}
+		if lex, ok := mm["lex"].(bool); ok {
+			opts.Match.Lex = &lex
+		}
+		if tok, ok := mm["token"].(map[string]any); ok {
+			opts.Match.Token = make(map[string]*regexp.Regexp, len(tok))
+			for name, v := range tok {
+				if re, ok := v.(*regexp.Regexp); ok {
+					opts.Match.Token[name] = re
+				}
+			}
+		}
+		if val, ok := mm["value"].(map[string]any); ok {
+			opts.Match.Value = make(map[string]*MatchValueSpec, len(val))
+			for name, v := range val {
+				if spec, ok := v.(map[string]any); ok {
+					mvs := &MatchValueSpec{}
+					if re, ok := spec["match"].(*regexp.Regexp); ok {
+						mvs.Match = re
+					}
+					if fn, ok := spec["val"].(func([]string) any); ok {
+						mvs.Val = fn
+					}
+					opts.Match.Value[name] = mvs
+				}
+			}
+		}
+	}
+
+	// TokenSet options (TS: options.tokenSet)
+	if ts, ok := m["tokenSet"].(map[string]any); ok {
+		opts.TokenSet = make(map[string][]string, len(ts))
+		for name, v := range ts {
+			switch arr := v.(type) {
+			case []any:
+				var names []string
+				for _, item := range arr {
+					if s, ok := item.(string); ok {
+						names = append(names, s)
+					}
+					// nil entries are skipped (matching TS where null entries are filtered)
+				}
+				opts.TokenSet[name] = names
+			case []string:
+				opts.TokenSet[name] = arr
+			}
 		}
 	}
 

--- a/test/grammar.test.js
+++ b/test/grammar.test.js
@@ -402,11 +402,12 @@ describe('grammar-options', () => {
 
   it('options-regex-number-exclude', () => {
     // Use @/…/ for number.exclude to reject leading-zero numbers.
+    // Note: ^0[0-9]+$ properly matches "01", "023" etc. but not "0" alone.
     let j = Jsonic.make()
     j.grammar({
       options: {
         number: {
-          exclude: '@/^00+/',
+          exclude: '@/^0[0-9]+$/',
         },
       },
     })

--- a/test/grammar.test.js
+++ b/test/grammar.test.js
@@ -534,6 +534,56 @@ describe('grammar-options', () => {
   })
 
 
+  it('options-regex-match-value', () => {
+    // Use @/…/ in match.value for regexp-based value matching.
+    // match.value runs against the forward source, so no $ anchor.
+    let j = Jsonic.make()
+    j.grammar({
+      ref: {
+        '@valOn': () => true,
+        '@valOff': () => false,
+      },
+      options: {
+        match: {
+          value: {
+            on: { match: '@/^on/i', val: '@valOn' },
+            off: { match: '@/^off/i', val: '@valOff' },
+          },
+        },
+      },
+    })
+
+    assert.deepEqual(j('a:ON,b:off'), { a: true, b: false })
+    assert.deepEqual(j('a:on'), { a: true })
+  })
+
+
+  it('options-regex-resolve-nested', () => {
+    // @/…/ resolution works inside nested option objects.
+    let j = Jsonic.make()
+    j.grammar({
+      ref: {
+        '@valYes': () => 'yes!',
+      },
+      options: {
+        value: {
+          def: {
+            y: { val: '@valYes', match: '@/^y$/i' },
+          },
+        },
+        number: {
+          exclude: '@/^0[0-9]+$/',
+        },
+      },
+    })
+
+    // Both nested @/…/ patterns resolve correctly.
+    assert.deepEqual(j('a:Y'), { a: 'yes!' })
+    assert.deepEqual(j('a:01'), { a: '01' })
+    assert.deepEqual(j('a:42'), { a: 42 })
+  })
+
+
   it('options-escape-at-prefix', () => {
     // @@ escapes to a literal @ string.
     let j = Jsonic.make()


### PR DESCRIPTION
## Summary
This PR adds comprehensive regexp support to the Jsonic parser, enabling declarative regex-based matching for numbers, values, and custom tokens. It mirrors TypeScript grammar functionality and allows regexps to be specified via the `@/…/` syntax in grammar options.

## Key Changes

- **Regexp syntax support**: Added `@/pattern/flags` syntax for declaring regexps in grammar options, with `@@` escaping to literal `@` strings
- **Number exclusion**: Implemented `number.exclude` as a regexp to filter number-like strings (e.g., reject leading-zero numbers)
- **Value regex matching**: Added `value.def[name].match` regexp support for keyword matching with optional value transformation functions
- **Custom token matching**: Implemented `match.token` for regexp-based custom token recognition with priority ordering
- **Custom value matching**: Added `match.value` for regexp-based value matching against forward source with optional transformers
- **Token sets**: Introduced `tokenSet` option to customize token groupings (VAL, KEY, etc.)
- **Typed API support**: Extended `Options`, `ValueDef`, and new `MatchOptions`/`MatchValueSpec` types to support regexp configuration programmatically
- **Lexer enhancements**: 
  - Added `matchMatch()` method implementing priority 1e6 matcher for custom regexp matching
  - Added `ValueDefRe` map for regex-based value definitions
  - Enhanced `matchText()` to check regex value definitions after exact matches
  - Added `MatchValueEntry` struct for resolved match.value entries
- **Resolution logic**: Extended `ResolveFuncRefs()` to recursively resolve `@/…/` patterns in nested maps and slices
- **Options mapping**: Updated `MapToOptions()` to handle regexp resolution from declarative grammar specs
- **Plugin integration**: Enhanced `SetOptions()` to preserve and merge match token/value entries across multiple calls

## Notable Implementation Details

- Regexps are resolved during grammar setup via `ResolveFuncRefs()`, converting `@/pattern/flags` strings to compiled `*regexp.Regexp` objects
- Match matchers run at priority 1e6, before custom matchers, ensuring consistent ordering
- Token matching validates that matched tokens are expected at the current rule position
- Value regex definitions support both exact text matching and forward-source matching via the `Consume` flag
- The implementation maintains backward compatibility while adding new optional features
- Comprehensive test coverage mirrors TypeScript grammar tests for parity verification

https://claude.ai/code/session_01MxPin9vfbBSw4aoGpk3Rpy