### PR TITLE
Support rule definitions in GrammarText/grammar(string)

### DIFF
--- a/go/grammar_decl_test.go
+++ b/go/grammar_decl_test.go
@@ -1460,6 +1460,65 @@ func TestGrammarTextFlatOptions(t *testing.T) {
 	}
 }
 
+func TestGrammarTextOptionsAndRules(t *testing.T) {
+	// GrammarText processes both options and rule definitions from text.
+	j := Make()
+	err := j.GrammarText(`
+		options: { number: { sep: "_" } },
+		rule: {
+			val: {
+				close: [
+					{ s: "#ZZ", g: "test,jsonic" }
+				]
+			}
+		}
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Options took effect.
+	result, err := j.Parse("a:1_000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != float64(1000) {
+		t.Errorf("expected a:1000, got %v", m["a"])
+	}
+}
+
+func TestGrammarTextRulesWithFuncRef(t *testing.T) {
+	// GrammarText can define rules with @funcRef actions when Ref is
+	// provided separately via Grammar after GrammarText sets up the structure.
+	j := Make()
+
+	// First apply rules via text with a group tag.
+	err := j.GrammarText(`
+		rule: {
+			val: {
+				close: [
+					{ s: "#ZZ", g: "custom-from-text" }
+				]
+			}
+		}
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the rule alt was added.
+	found := false
+	for _, alt := range j.RSM()["val"].Close {
+		if alt.G == "custom-from-text" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected rule alt with group 'custom-from-text'")
+	}
+}
+
 func TestGrammarTextInvalidSource(t *testing.T) {
 	j := Make()
 	// Empty string should not error (jsonic allows empty source by default).

--- a/go/grammarspec.go
+++ b/go/grammarspec.go
@@ -146,11 +146,99 @@ func (j *Jsonic) GrammarText(text string) error {
 	gs := &GrammarSpec{}
 	if optionsMap, ok := gsMap["options"].(map[string]any); ok {
 		gs.OptionsMap = optionsMap
-	} else {
-		// No "options" wrapper — treat the entire map as options.
+	} else if _, hasRule := gsMap["rule"]; !hasRule {
+		// No "options" wrapper and no "rule" key — treat the entire map as options.
 		gs.OptionsMap = gsMap
 	}
+	if ruleMap, ok := gsMap["rule"].(map[string]any); ok {
+		gs.Rule = mapToGrammarRules(ruleMap)
+	}
 	return j.Grammar(gs)
+}
+
+// mapToGrammarRules converts a parsed rule map into typed GrammarRuleSpec map.
+func mapToGrammarRules(ruleMap map[string]any) map[string]*GrammarRuleSpec {
+	rules := make(map[string]*GrammarRuleSpec, len(ruleMap))
+	for name, v := range ruleMap {
+		rm, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		spec := &GrammarRuleSpec{}
+		if open, ok := rm["open"]; ok {
+			spec.Open = parseGrammarAlts(open)
+		}
+		if close, ok := rm["close"]; ok {
+			spec.Close = parseGrammarAlts(close)
+		}
+		rules[name] = spec
+	}
+	return rules
+}
+
+// parseGrammarAlts converts a parsed alt list ([]any of maps) to []*GrammarAltSpec.
+func parseGrammarAlts(v any) []*GrammarAltSpec {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	alts := make([]*GrammarAltSpec, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		alt := mapToGrammarAltSpec(m)
+		alts = append(alts, alt)
+	}
+	return alts
+}
+
+// mapToGrammarAltSpec converts a parsed map to a GrammarAltSpec.
+func mapToGrammarAltSpec(m map[string]any) *GrammarAltSpec {
+	alt := &GrammarAltSpec{}
+	if v, ok := m["s"]; ok {
+		alt.S = v // string or []string ([]any of strings)
+	}
+	if v, ok := m["b"]; ok {
+		alt.B = v // int (float64 from parse) or FuncRef string
+	}
+	if v, ok := m["p"].(string); ok {
+		alt.P = v
+	}
+	if v, ok := m["r"].(string); ok {
+		alt.R = v
+	}
+	if v, ok := m["a"].(string); ok {
+		alt.A = v
+	}
+	if v, ok := m["e"].(string); ok {
+		alt.E = v
+	}
+	if v, ok := m["h"].(string); ok {
+		alt.H = v
+	}
+	if v, ok := m["c"]; ok {
+		alt.C = v // FuncRef string or map[string]any
+	}
+	if v, ok := m["n"].(map[string]any); ok {
+		alt.N = make(map[string]int, len(v))
+		for k, val := range v {
+			if f, ok := val.(float64); ok {
+				alt.N[k] = int(f)
+			}
+		}
+	}
+	if v, ok := m["u"].(map[string]any); ok {
+		alt.U = v
+	}
+	if v, ok := m["k"].(map[string]any); ok {
+		alt.K = v
+	}
+	if v, ok := m["g"].(string); ok {
+		alt.G = v
+	}
+	return alt
 }
 
 // applyGrammarAlts resolves and applies grammar alts to a rule spec.

--- a/test/grammar.test.js
+++ b/test/grammar.test.js
@@ -668,6 +668,24 @@ describe('grammar-options', () => {
   })
 
 
+  it('grammar-text-string-options-and-rules', () => {
+    // grammar(string) processes both options and rule definitions.
+    let j = Jsonic.make()
+    j.grammar(`
+      options: { number: { sep: "_" } },
+      rule: {
+        val: {
+          close: [
+            { s: "#ZZ", g: "test,jsonic" }
+          ]
+        }
+      }
+    `)
+    // Options took effect.
+    assert.deepEqual(j('a:1_000'), { a: 1000 })
+  })
+
+
   it('skip-sentinel-exported', () => {
     // SKIP is available on the Jsonic object as an immutable symbol.
     assert.equal(typeof Jsonic.SKIP, 'symbol')


### PR DESCRIPTION
Go's GrammarText previously only processed options from parsed text, silently ignoring rule definitions. Now it converts the parsed "rule" map into typed GrammarRuleSpec/GrammarAltSpec structs and passes them to Grammar(), matching TS behavior where grammar(string) processes both options and rule keys.

Added mapToGrammarRules, parseGrammarAlts, and mapToGrammarAltSpec conversion functions that handle all serializable alt fields (s, b, p, r, a, e, h, c, n, u, k, g). Function-valued fields use @funcRef strings resolved via the Ref map during Grammar().

Also fixed flat-options detection: when the parsed text has a "rule" key but no "options" key, the map is no longer treated as flat options.

https://claude.ai/code/session_01MxPin9vfbBSw4aoGpk3Rpy