### PR TITLE
Fix GrammarText to handle {alts, inject} rule form

### DIFF
--- a/go/grammar_decl_test.go
+++ b/go/grammar_decl_test.go
@@ -1519,6 +1519,51 @@ func TestGrammarTextRulesWithFuncRef(t *testing.T) {
 	}
 }
 
+func TestGrammarTextWithInjectAndExclude(t *testing.T) {
+	// Regression: GrammarText with {alts, inject} form was not parsed,
+	// so rule alts were silently dropped, breaking string matching when
+	// combined with rule.exclude.
+	j := Make()
+	err := j.GrammarText(`
+		options: { text:{lex:false}, string:{chars:'"'}, rule:{finish:false} },
+		rule: { val: { open: { alts:[{s:'#ZZ', g:jsonc}], inject:{append:true} } } }
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j.SetOptions(Options{Rule: &RuleOptions{Exclude: "jsonic,imp"}})
+
+	// Complete string should parse.
+	result, err := j.Parse(`"test"`)
+	if err != nil {
+		t.Fatalf("complete string failed: %v", err)
+	}
+	if result != "test" {
+		t.Errorf("expected 'test', got %v", result)
+	}
+
+	// Unterminated string should produce unterminated_string, not unexpected.
+	_, err = j.Parse(`"test`)
+	if err == nil {
+		t.Fatal("expected error for unterminated string")
+	}
+	if je, ok := err.(*JsonicError); ok {
+		if je.Code != "unterminated_string" {
+			t.Errorf("expected unterminated_string, got %s", je.Code)
+		}
+	}
+
+	// JSON structures should work.
+	result, err = j.Parse(`{"a":"b","c":1}`)
+	if err != nil {
+		t.Fatalf("JSON object failed: %v", err)
+	}
+	m := result.(map[string]any)
+	if m["a"] != "b" || m["c"] != float64(1) {
+		t.Errorf("expected {a:b, c:1}, got %v", m)
+	}
+}
+
 func TestGrammarTextThenSetOptionsPreserved(t *testing.T) {
 	// GrammarText sets options and rules. A subsequent SetOptions must
 	// preserve both the options (via deep merge) and the rule modifications.

--- a/go/grammarspec.go
+++ b/go/grammarspec.go
@@ -166,22 +166,63 @@ func mapToGrammarRules(ruleMap map[string]any) map[string]*GrammarRuleSpec {
 		}
 		spec := &GrammarRuleSpec{}
 		if open, ok := rm["open"]; ok {
-			spec.Open = parseGrammarAlts(open)
+			spec.Open = parseGrammarAltsOrSpec(open)
 		}
 		if close, ok := rm["close"]; ok {
-			spec.Close = parseGrammarAlts(close)
+			spec.Close = parseGrammarAltsOrSpec(close)
 		}
 		rules[name] = spec
 	}
 	return rules
 }
 
-// parseGrammarAlts converts a parsed alt list ([]any of maps) to []*GrammarAltSpec.
-func parseGrammarAlts(v any) []*GrammarAltSpec {
-	arr, ok := v.([]any)
-	if !ok {
-		return nil
+// parseGrammarAltsOrSpec handles both forms:
+//   - []any (plain alt array) → []*GrammarAltSpec
+//   - map[string]any with "alts" and "inject" → *GrammarAltListSpec
+func parseGrammarAltsOrSpec(v any) any {
+	// Plain array form.
+	if arr, ok := v.([]any); ok {
+		return parseGrammarAlts(arr)
 	}
+	// Map form with alts + inject.
+	if m, ok := v.(map[string]any); ok {
+		altsRaw, hasAlts := m["alts"]
+		if !hasAlts {
+			return nil
+		}
+		altsArr, ok := altsRaw.([]any)
+		if !ok {
+			return nil
+		}
+		alts := parseGrammarAlts(altsArr)
+		spec := &GrammarAltListSpec{Alts: alts}
+		if injectRaw, ok := m["inject"].(map[string]any); ok {
+			spec.Inject = &GrammarInjectSpec{}
+			if append_, ok := injectRaw["append"].(bool); ok {
+				spec.Inject.Append = append_
+			}
+			if del, ok := injectRaw["delete"].([]any); ok {
+				for _, d := range del {
+					if f, ok := d.(float64); ok {
+						spec.Inject.Delete = append(spec.Inject.Delete, int(f))
+					}
+				}
+			}
+			if mv, ok := injectRaw["move"].([]any); ok {
+				for _, m := range mv {
+					if f, ok := m.(float64); ok {
+						spec.Inject.Move = append(spec.Inject.Move, int(f))
+					}
+				}
+			}
+		}
+		return spec
+	}
+	return nil
+}
+
+// parseGrammarAlts converts a parsed alt array ([]any of maps) to []*GrammarAltSpec.
+func parseGrammarAlts(arr []any) []*GrammarAltSpec {
 	alts := make([]*GrammarAltSpec, 0, len(arr))
 	for _, item := range arr {
 		m, ok := item.(map[string]any)


### PR DESCRIPTION
GrammarText's parseGrammarAlts only handled plain []any arrays for rule open/close specs. The {alts:[...], inject:{append:true}} map form (GrammarAltListSpec) was silently dropped because the []any type assertion failed on the map.

This caused rule alts defined via GrammarText with inject modifiers to be lost, so when combined with rule.exclude the grammar was left in a broken state (missing alts → string matching failed with "unexpected" instead of "unterminated_string").

Fix: parseGrammarAltsOrSpec now handles both forms, converting the map form into a *GrammarAltListSpec with full inject support (append, delete, move).

https://claude.ai/code/session_01MxPin9vfbBSw4aoGpk3Rpy