### PR TITLE
go: preserve IgnoreSet/ValSet/KeySet across SetOptions

### DIFF
--- a/go/plugin.go
+++ b/go/plugin.go
@@ -526,6 +526,19 @@ func (j *Jsonic) SetOptions(opts Options) *Jsonic {
 	cfg.FixedSorted = j.parser.Config.FixedSorted
 	cfg.TinNames = j.parser.Config.TinNames
 	cfg.CustomMatchers = j.parser.Config.CustomMatchers
+	// Preserve token sets. buildConfig unconditionally resets IgnoreSet/
+	// ValSet/KeySet to defaults, which would clobber SetTokenSet mutations
+	// made by plugins or prior calls. opts.TokenSet below reapplies any
+	// explicit override from the incoming options.
+	if j.parser.Config.IgnoreSet != nil {
+		cfg.IgnoreSet = j.parser.Config.IgnoreSet
+	}
+	if j.parser.Config.ValSet != nil {
+		cfg.ValSet = j.parser.Config.ValSet
+	}
+	if j.parser.Config.KeySet != nil {
+		cfg.KeySet = j.parser.Config.KeySet
+	}
 	// Preserve match token/value entries added by prior SetOptions/Grammar calls.
 	if len(j.parser.Config.MatchTokens) > 0 {
 		for k, v := range j.parser.Config.MatchTokens {

--- a/go/plugin_test.go
+++ b/go/plugin_test.go
@@ -1252,6 +1252,42 @@ func TestDeriveInheritsIgnoreSet(t *testing.T) {
 	}
 }
 
+func TestSetOptionsPreservesIgnoreSet(t *testing.T) {
+	// A plugin (or prior call) may mutate IGNORE via SetTokenSet. A
+	// subsequent SetOptions — including one triggered internally by
+	// Grammar() — must not silently reset IGNORE to defaults.
+	j := Make()
+	j.SetTokenSet("IGNORE", []Tin{TinSP, TinCM}) // Remove LN
+
+	// Unrelated SetOptions call must not reset the IGNORE set.
+	yes := true
+	j.SetOptions(Options{Number: &NumberOptions{Hex: &yes}})
+
+	if j.Config().IgnoreSet[TinLN] {
+		t.Error("SetOptions reset IgnoreSet — TinLN re-added after unrelated options change")
+	}
+	if len(j.TokenSet("IGNORE")) != 2 {
+		t.Errorf("expected 2 IGNORE tokens after SetOptions, got %d", len(j.TokenSet("IGNORE")))
+	}
+
+	// Grammar() applies Options via SetOptions internally — same guarantee must hold.
+	if err := j.Grammar(&GrammarSpec{Options: &Options{Tag: "t"}}); err != nil {
+		t.Fatalf("Grammar failed: %v", err)
+	}
+	if j.Config().IgnoreSet[TinLN] {
+		t.Error("Grammar's internal SetOptions reset IgnoreSet — TinLN re-added")
+	}
+	if len(j.TokenSet("IGNORE")) != 2 {
+		t.Errorf("expected 2 IGNORE tokens after Grammar, got %d", len(j.TokenSet("IGNORE")))
+	}
+
+	// Explicit TokenSet override in the new options must still win.
+	j.SetOptions(Options{TokenSet: map[string][]string{"IGNORE": {"#SP"}}})
+	if len(j.TokenSet("IGNORE")) != 1 {
+		t.Errorf("expected TokenSet override to shrink IGNORE to 1 token, got %d", len(j.TokenSet("IGNORE")))
+	}
+}
+
 func TestSetTokenSetVAL(t *testing.T) {
 	j := Make()
 


### PR DESCRIPTION
buildConfig unconditionally resets IgnoreSet/ValSet/KeySet to defaults,
so any subsequent SetOptions call (including the one Grammar() runs
internally) silently discarded SetTokenSet mutations made by plugins
or prior calls. This broke plugin flows that remove #LN from IGNORE
for row-separated formats — #LN would be re-added after Grammar().

Preserve the existing token sets before applying buildConfig's
defaults, mirroring how FixedTokens and friends are already handled.
An explicit opts.TokenSet override still wins, since it's reapplied
after the buildConfig result is copied.

https://claude.ai/code/session_01QV7mtaUmS8eBeEyA4JNyCL